### PR TITLE
risc-v: Add support for rv32im rv32ima

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "framework-zephyr",
+  "version": "2.20500.210226",
+  "description": "Zephyr is a new generation, scalable, optimized, secure RTOS for multiple hardware architectures",
+  "keywords": [
+    "framework",
+    "rtos",
+    "hal"
+  ],
+  "homepage": "https://www.zephyrproject.org",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zephyrproject-rtos/zephyr"
+  }
+}
+

--- a/scripts/platformio/platformio-build.py
+++ b/scripts/platformio/platformio-build.py
@@ -76,7 +76,7 @@ PLATFORMS_WITH_EXTERNAL_HAL = {
 def get_board_architecture(board_config):
     if board_config.get("build.cpu", "").lower().startswith("cortex"):
         return "arm"
-    elif board_config.get("build.march", "") in ("rv64imac", "rv32imac"):
+    elif board_config.get("build.march", "") in ("rv64imac", "rv32im", "rv32ima", "rv32imac"):
         return "riscv"
     elif board_config.get("build.mcu") == "esp32":
         return "xtensa32"


### PR DESCRIPTION
Also allow the support for the more basic opcode sets.

Would be nice to get this included for LiteX.