### PR TITLE
Add PlatformIO build support for Teensy

### DIFF
--- a/scripts/platformio/platformio-build.py
+++ b/scripts/platformio/platformio-build.py
@@ -78,6 +78,7 @@ PLATFORMS_WITH_EXTERNAL_HAL = {
     "nordicnrf52": ["st", "nordic"],
     "nxplpc": ["st", "nxp"],
     "nxpimxrt": ["st", "nxp"],
+    "teensy": ["st", "nxp"],
 }
 
 


### PR DESCRIPTION
This is required for [https://github.com/platformio/platform-teensy/pull/83](https://github.com/platformio/platform-teensy/pull/83)